### PR TITLE
Floor plan unit status added

### DIFF
--- a/leasepeek/readers/reader_functions/floorplan_survey.py
+++ b/leasepeek/readers/reader_functions/floorplan_survey.py
@@ -1,7 +1,7 @@
 # Defaultdict automatically initializes dictionary entries to a default value if the key has not been set yet. This means one doesn't need to check if the key exists in the dictionary before appending to it.
 from collections import defaultdict
 
-status_keywords = {'upcoming', 'approved', 'Future Residents/Applicants', 'Applicant', 'Pending renewal', 'Former resident', 'Former applicant'}
+ignore_unit_keywords = {'upcoming', 'approved', 'Future Residents/Applicants', 'Applicant', 'applicant', 'Pending renewal', 'Former resident', 'Former applicant'}
 occupied_keywords = {'Occupied', 'occupied', 'Occupied-NTV', 'Occupied-NTVL', 'O', 'NR', 'NU'}
 
 def floorplan_survey(data):
@@ -10,7 +10,7 @@ def floorplan_survey(data):
 
     # Add unit floor plan data to the floor_plans dictionary
     for unit in data:
-        if unit['status'] not in status_keywords:
+        if unit['status'] not in ignore_unit_keywords:
             try:
                 market = unit['market']
                 rent = unit['rent']
@@ -19,18 +19,29 @@ def floorplan_survey(data):
                 floorplans[unit['floorplan']].append({'market': market, 'rent': rent, 'sqft': sqft, 'status': status})
             except (ValueError, TypeError) as e:
                 print(f"Error converting values for unit. Details: {e}")
-
+        else:
+            continue
 
     # Modify the floorplans dictionary to give relevant information
     for plan, units in floorplans.items():
         market_sum = sum(unit['market'] for unit in units)
         plan_count = len(units)
-        rent_sum = sum(unit['rent'] for unit in units)
-        rent_count = sum(1 for unit in units if unit['rent'] > 0 or unit['status'] in occupied_keywords)
+        rent_sum = sum(unit['rent'] for unit in units if unit['status'] in occupied_keywords)
+        rent_count = sum(1 for unit in units if unit['status'] in occupied_keywords)
         sqft_sum = sum(unit['sqft'] for unit in units)
         avg_market = round(market_sum / plan_count, 2)
         avg_rent = round(rent_sum / rent_count, 2) if rent_count > 0 else 0
         avg_sqft = round(sqft_sum / plan_count, 2) if sqft_sum > 0 else 0
+        
+        status_count = {}
+        for unit in units:
+            status = unit['status']
+            if status in status_count:
+                status_count[status] += 1
+            else:
+                status_count[status] = 1
+
+        
 
         floorplans[plan] = {
             'avgRent': avg_rent,
@@ -39,10 +50,11 @@ def floorplan_survey(data):
             'sumMarket': market_sum,
             'unitCount': plan_count,
             'avgSqft': avg_sqft,
+            'unitStatuses': status_count,
         }
 
     # for i, plan in enumerate(floorplans):
     #     print(f"07_TEST_FILE_FLOORPLAN_{i+1} = '{plan}'")
-
+        
     # Convert defaultdict back to dict for the return value
     return dict(floorplans)

--- a/leasepeek/readers/reader_functions/loss_to_lease.py
+++ b/leasepeek/readers/reader_functions/loss_to_lease.py
@@ -1,6 +1,6 @@
 
 
-status_keywords = {'upcoming', 'approved', 'Future Residents/Applicants', 'Applicant', 'Pending renewal', 'Former resident', 'Former applicant'}
+status_keywords = {'upcoming', 'approved', 'Future Residents/Applicants', 'Applicant', 'Pending renewal', 'Former resident', 'Former applicant', 'applicant'}
 
 def find_loss_to_lease(unit_data):
     market_sum = 0

--- a/leasepeek/readers/reader_functions/recent_leases.py
+++ b/leasepeek/readers/reader_functions/recent_leases.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-keywords = {'Former applicant', 'Future Residents/Applicants'}
+keywords = {'Former applicant', 'Future Residents/Applicants', 'Applicant'}
 
 def recent_leases(unit_data, as_of_date_str):
     if as_of_date_str == 'Date not found':

--- a/leasepeek/readers/reader_functions/recent_leases.py
+++ b/leasepeek/readers/reader_functions/recent_leases.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-keywords = {'Former applicant', 'Future Residents/Applicants', 'Applicant'}
+keywords = {'Former applicant', 'Future Residents/Applicants', 'Applicant', 'applicant'}
 
 def recent_leases(unit_data, as_of_date_str):
     if as_of_date_str == 'Date not found':

--- a/leasepeek/readers/reader_functions/vacancy.py
+++ b/leasepeek/readers/reader_functions/vacancy.py
@@ -44,14 +44,14 @@ def vacancy(unit_data):
     vacants = 0
     # Total number of units in the dataset.
     total_units = len(unit_data)
-
+    
     # Process each unit's data.
     for unit in unit_data:
         # Handle units with combined statuses that require further classification.
         if unit['status'] in combined_vacancy_keywords:
             # If the status indicates future residents or applicants, increment the 'Applicant' count.
             if unit['status'] ==  "Future Residents/Applicants":
-                unit['status'] = 'Applicant'
+                unit['status'] = 'applicant'
                 if 'Applicant' in vacancy_statuses:
                     vacancy_statuses['Applicant'] += 1
                 else:
@@ -59,28 +59,28 @@ def vacancy(unit_data):
             else:
                 # If the tenant field contains 'vacant', increment the 'Vacant' count.
                 if 'vacant' in unit['tenant'].lower():
-                    unit['status'] = 'Vacant'
+                    unit['status'] = 'vacant'
                     if 'Vacant' in vacancy_statuses:
                         vacancy_statuses['Vacant'] += 1
                     else:
                         vacancy_statuses['Vacant'] = 1
                 # If there's a model unit, increment the 'Model' count.
                 elif unit['tenant'].lower() in model_unit_keywords:
-                    unit['status'] = 'Model'
+                    unit['status'] = 'model'
                     if 'Model' in vacancy_statuses:
                         vacancy_statuses['Model'] += 1
                     else:
                         vacancy_statuses['Model'] = 1
                 # If there's a down unit, increment the 'Down' count.
                 elif unit['tenant'].lower() in down_unit_keywords:
-                    unit['status'] = 'Down'
+                    unit['status'] = 'down'
                     if 'Down' in vacancy_statuses:
                         vacancy_statuses['Down'] += 1
                     else:
                         vacancy_statuses['Down'] = 1
                 # If none of the above, the unit is considered 'Occupied'.
                 else:
-                    unit['status'] = 'Occupied'
+                    unit['status'] = 'occupied'
                     if 'Occupied' in vacancy_statuses:
                         vacancy_statuses['Occupied'] += 1
                     else:
@@ -89,18 +89,30 @@ def vacancy(unit_data):
         # Handle units with explicit statuses.
         elif unit['status']:
             if unit['status'] in occupied_keywords:
-                unit['status'] = 'Occupied'
+                unit['status'] = 'occupied'
             # Increment the count for the unit's status.
                 if 'Occupied' in vacancy_statuses:
                     vacancy_statuses['Occupied'] += 1
                 else:
                     vacancy_statuses['Occupied'] = 1
             elif unit['status'] in vacant_keywords:
-                unit['status'] = 'Vacant'
+                unit['status'] = 'vacant'
                 if 'Vacant' in vacancy_statuses:
                     vacancy_statuses['Vacant'] += 1
                 else:
                     vacancy_statuses['Vacant'] = 1
+            elif unit['status'] in model_unit_keywords:
+                unit['status'] = 'model'
+                if 'Model' in vacancy_statuses:
+                    vacancy_statuses['Model'] += 1
+                else:
+                    vacancy_statuses['Model'] = 1
+            elif unit['status'] in down_unit_keywords:
+                unit['status'] = 'down'
+                if 'Down' in vacancy_statuses:
+                    vacancy_statuses['Down'] += 1
+                else:
+                    vacancy_statuses['Down'] = 1
             elif unit['status'] in ignore_keywords:
                 continue
             else:
@@ -112,27 +124,27 @@ def vacancy(unit_data):
         # For units without a status, check if 'vacant' is mentioned in the 'tenant' field.
         else:
             if any(keyword in 'vacant' in unit['tenant'].lower() for keyword in vacant_keywords):
-                unit['status'] = 'Vacant'
+                unit['status'] = 'vacant'
                 if 'Vacant' in vacancy_statuses:
                     vacancy_statuses['Vacant'] += 1
                 else:
                     vacancy_statuses['Vacant'] = 1
             elif any(keyword in unit['tenant'].lower() for keyword in model_unit_keywords):
-                unit['status'] = 'Model'
+                unit['status'] = 'model'
                 if 'Model' in vacancy_statuses:
                     vacancy_statuses['Model'] += 1
                 else:
                     vacancy_statuses['Model'] = 1
             # If there's a down unit, increment the 'Down' count.
             elif unit['tenant'].lower() in down_unit_keywords:
-                unit['status'] = 'Down'
+                unit['status'] = 'down'
                 if 'Down' in vacancy_statuses:
                     vacancy_statuses['Down'] += 1
                 else:
                     vacancy_statuses['Down'] = 1
             # If none of the above, the unit is considered 'Occupied'.
             else:
-                unit['status'] = 'Occupied'
+                unit['status'] = 'occupied'
                 if 'Occupied' in vacancy_statuses:
                     vacancy_statuses['Occupied'] += 1
                 else:

--- a/leasepeek/tests/data_validation/test_process_data_outputs_003.py
+++ b/leasepeek/tests/data_validation/test_process_data_outputs_003.py
@@ -62,8 +62,9 @@ class ProcessDataViewValuesTest(APITestCase):
         self.assertEqual(response_data['location'], os.environ.get('02_TEST_FILE_LOCATION'))
         self.assertEqual(response_data['totalUnits'], 300)
 
-        self.assertEqual(response_data['vacancy']['Occupied'], 276)
+        self.assertEqual(response_data['vacancy']['Occupied'], 275)
         self.assertEqual(response_data['vacancy']['Vacant'], 24)
+        self.assertEqual(response_data['vacancy']['Model'], 1)
        
         self.assertEqual(response_data['lossToLease']['marketSum'], 504484)
         self.assertEqual(response_data['lossToLease']['rentIncome'], 405967)

--- a/leasepeek/tests/data_validation/test_process_data_outputs_007.py
+++ b/leasepeek/tests/data_validation/test_process_data_outputs_007.py
@@ -72,7 +72,7 @@ class ProcessDataViewValuesTest(APITestCase):
         expired = "expired"
 
         floorplan1 = os.environ.get('07_TEST_FILE_FLOORPLAN_1')
-        self.assertEqual(response_data['floorplans'][floorplan1]['avgRent'], 1826.76)
+        self.assertEqual(response_data['floorplans'][floorplan1]['avgRent'], 1790.94)
         self.assertEqual(response_data['floorplans'][floorplan1]['sumRent'], 91338)
         self.assertEqual(response_data['floorplans'][floorplan1]['avgMarket'], 1859.52)
         self.assertEqual(response_data['floorplans'][floorplan1]['sumMarket'], 96695)


### PR DESCRIPTION
Now `floorplan_survey.py` includes unit status information (vacant, occupied, model, down, etc) on a per floorplan basis. This data will be used on the front end to not just show the amount of units per floorplan but the status of each unit as well.

Closes #11 